### PR TITLE
Config Patch

### DIFF
--- a/core/trial_configs/arrhenius_cooling.json
+++ b/core/trial_configs/arrhenius_cooling.json
@@ -1,25 +1,23 @@
 {
     "co2": {
         "from": 1,
-        "to": 2
+        "to": 0.67
     },
     "year": 1895,
     "grid": {
         "dims": {
-            "lat": 10,
-            "lon": 20
+            "lat": 15,
+            "lon": 30
         },
         "repr": "width"
     },
     "layers": 1,
-    "iters": 1,
+    "iters": 8,
     "aggregate_lat": "none",
     "aggregate_level": "none",
     "temp_src": "arrhenius",
     "humidity_src": "arrhenius",
-    "albedo_src": "flat",
+    "albedo_src": "landmask",
     "absorbance_src": "table",
-    "CO2_weight": "mean",
-    "H2O_weight": "mean",
     "scale": [-8, 8]
 }

--- a/core/trial_configs/arrhenius_legacy.json
+++ b/core/trial_configs/arrhenius_legacy.json
@@ -1,0 +1,23 @@
+{
+    "co2": {
+        "from": 1,
+        "to": 2
+    },
+    "year": 1895,
+    "grid": {
+        "dims": {
+            "lat": 10,
+            "lon": 20
+        },
+        "repr": "width"
+    },
+    "layers": 1,
+    "iters": 1,
+    "aggregate_lat": "before",
+    "aggregate_level": "none",
+    "temp_src": "arrhenius",
+    "humidity_src": "arrhenius",
+    "albedo_src": "flat",
+    "absorbance_src": "table",
+    "scale": [-8, 8]
+}

--- a/core/trial_configs/arrhenius_modern.json
+++ b/core/trial_configs/arrhenius_modern.json
@@ -1,0 +1,23 @@
+{
+    "co2": {
+        "from": 1,
+        "to": 2
+    },
+    "year": 2017,
+    "grid": {
+        "dims": {
+            "lat": 5,
+            "lon": 6
+        },
+        "repr": "width"
+    },
+    "iters": 1,
+    "aggregate_lat": "none",
+    "aggregate_level": "none",
+    "temp_src": "ncar",
+    "humidity_src": "ncar",
+    "albedo_src": "landmask",
+    "absorbance_src": "modern",
+    "pressure_src": "ncar",
+    "scale": [-0.15, 0.15]
+}

--- a/core/trial_configs/arrhenius_multilayer.json
+++ b/core/trial_configs/arrhenius_multilayer.json
@@ -1,0 +1,23 @@
+{
+    "co2": {
+        "from": 1,
+        "to": 2
+    },
+    "year": 2017,
+    "grid": {
+        "dims": {
+            "lat": 20,
+            "lon": 40
+        },
+        "repr": "width"
+    },
+    "iters": 1,
+    "aggregate_lat": "none",
+    "aggregate_level": "none",
+    "temp_src": "ncar",
+    "humidity_src": "ncar",
+    "albedo_src": "landmask",
+    "absorbance_src": "multilayer",
+    "pressure_src": "ncar",
+    "scale": [-1, 1]
+}


### PR DESCRIPTION
Some ease-of-use patches to the configuration system. Configuration will now update its auto-generated ID when setter methods are called on it after initialization. New external configuration files have been added in the trial_config directory.