### PR TITLE
Update conda script to force python3.11

### DIFF
--- a/data/resources.py
+++ b/data/resources.py
@@ -11,7 +11,7 @@ OUTPUT_REL_PATH = path.join(MAIN_PATH, 'website', 'output/')
 DATASETS = {
     'arrhenius': "arrhenius_data.nc",
     'temperature': {
-        'berkeley': 'Land_And_Ocean_LatLong1.nc',
+        'berkeley': 'Land_and_Ocean_LatLong1.nc',
         'NCEP/NCAR': 'air.mon.mean.nc'
     },
     'albedo': None,

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,7 @@
 
 # Create a new environment for the project, given as the first argument.
-if [ $# -gt 0 ]
-then
-    conda create -n $1 python=3.11
-    source activate $1
-fi
+conda create -n $1 python=3.11
+source activate $1
 
 # Install dependencies.
 # Note: Some project dependencies are implicit, as they are installed
@@ -23,7 +20,4 @@ wget -nc -P data/models https://berkeley-earth-temperature.s3.us-west-1.amazonaw
 wget -nc -P data/models ftp://ftp.cdc.noaa.gov/Datasets/ncep.reanalysis.derived/pressure/air.mon.mean.nc
 wget -nc -P data/models ftp://ftp.cdc.noaa.gov/Datasets/ncep.reanalysis.derived/pressure/rhum.mon.mean.nc
 
-if [ $# -gt 0 ]
-then
-  echo "Now run: conda activate $1"
-fi
+echo "Now run: conda activate $1"

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 # Create a new environment for the project, given as the first argument.
 if [ $# -gt 0 ]
 then
-    conda create -n $1
+    conda create -n $1 python=3.11
     source activate $1
 fi
 
@@ -12,7 +12,7 @@ fi
 conda install -c conda-forge pyresample netCDF4 basemap jsonschema frozendict
 
 # Install project packages.
-pip install -e .
+python -m pip install -e .
 
 # Write environment variables that are used by the project.
 export PYTHONHASHSEED=0
@@ -22,3 +22,8 @@ export ARRHENIUS_MAIN_PATH=`pwd`
 wget -nc -P data/models https://berkeley-earth-temperature.s3.us-west-1.amazonaws.com/Global/Gridded/Land_and_Ocean_LatLong1.nc
 wget -nc -P data/models ftp://ftp.cdc.noaa.gov/Datasets/ncep.reanalysis.derived/pressure/air.mon.mean.nc
 wget -nc -P data/models ftp://ftp.cdc.noaa.gov/Datasets/ncep.reanalysis.derived/pressure/rhum.mon.mean.nc
+
+if [ $# -gt 0 ]
+then
+  echo "Now run: conda activate $1"
+fi

--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,8 @@
+# Check number of arguments, if its not 1 then give usage
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <environment_name>"
+    exit 1
+fi
 
 # Create a new environment for the project, given as the first argument.
 conda create -n $1 python=3.11


### PR DESCRIPTION
`lowtran` uses `distutils` which was deprecated in Python 3.12 onwards, so this PR updates the conda script to specify the Python version (and adds a tiny bit more user information).

This also changes `install.sh` so that a conda environment is required (in order to ensure 3.11 is used) rather than optional